### PR TITLE
Script cleanup

### DIFF
--- a/Sprite.gd
+++ b/Sprite.gd
@@ -4,13 +4,12 @@ var mouse_in = false
 var dragging = false
 
 func _process(delta):
-	if (mouse_in && Input.is_action_pressed("left_click")):
+	if mouse_in && Input.is_action_pressed("left_click"):
 		dragging = true
 		
-	if (dragging && Input.is_action_pressed("left_click")):
-		var position = get_viewport().get_mouse_position()
+	if dragging && Input.is_action_pressed("left_click"):
+		position = get_viewport().get_mouse_position()
 		
-		set_position(position)
 	else:
 		dragging = false
 


### PR DESCRIPTION
A small suggestion: there's no need to create a new variable shadowing the `position` property. You can just set it directly.

I also removed unnecessary `()`. GDScript doesn't need them, and the official GDScript style guide suggests avoiding them.

Great concise demo!